### PR TITLE
Rails6.0.3（APIモード） + MySQL5.7.34 のボイラープレートを作成

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,8 +4,10 @@ Dockerを利用した開発環境のボイラープレートです。
 
 ## 一覧
 
-|        directory         | Linux distribution |   Languages   |        Framework          |    Databases    |
-|:------------------------:|:------------------:|:-------------:|:-------------------------:|:---------------:|
-|     [rails6][rails6]     |       Debian       | Ruby（2.7.3） | Ruby on Rails（~> 6.0.3） | MySQL（5.7.34） |
+|          directory           | Linux distribution |   Languages   |        Framework          |    Databases    |
+|:----------------------------:|:------------------:|:-------------:|:-------------------------:|:---------------:|
+|       [rails6][rails6]       |       Debian       | Ruby（2.7.3） | Ruby on Rails（~> 6.0.3） | MySQL（5.7.34） |
+|   [rails6_api][rails6_api]   |       Debian       | Ruby（2.7.3） | Ruby on Rails（~> 6.0.3） | MySQL（5.7.34） |
 
 [rails6]:https://github.com/tom0418/Setup/tree/main/docker/rails6
+[rails6_api]:https://github.com/tom0418/Setup/tree/main/docker/rails6_api

--- a/docker/rails6/README.md
+++ b/docker/rails6/README.md
@@ -59,9 +59,10 @@ Docker Compose を使用して Rails6 / MySQL5.7 の開発環境をセットア�
     ```
 
 1. コンテナを立ち上げる
-   ```
+
+    ```shell
     $ docker compose up
-    ``````
+    ```
 
 1. データベースを作成
 

--- a/docker/rials6_api/Dockerfile
+++ b/docker/rials6_api/Dockerfile
@@ -1,0 +1,33 @@
+# 2021.04.29 時点での最新安定板
+FROM ruby:2.7.3
+
+# ロケール環境変数をセット
+ENV LANG C.UTF-8
+
+# 必要なパッケージのインストール
+RUN apt-get update -qq && \
+    apt-get install -y build-essential \
+                       default-mysql-client \
+                       imagemagick \
+                       apt-transport-https
+
+# 作業ディレクトリの作成
+RUN mkdir /project_name
+ENV API_ROOT /project_name
+WORKDIR $API_ROOT
+
+# ローカルの Gemfile, Gemfile.lock を作業ディレクトリにコピーする
+COPY ./Gemfile* $API_ROOT/
+
+# yarn をインストール
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get install -y nodejs yarn
+
+# bundle install
+RUN gem uninstall bundler && gem install -N bundler
+RUN bundle install --jobs=4
+
+# ローカルのプロジェクトを作業ディレクトリにコピーする
+COPY . $API_ROOT

--- a/docker/rials6_api/Gemfile
+++ b/docker/rials6_api/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'rails', '~> 6.0.3'

--- a/docker/rials6_api/README.md
+++ b/docker/rials6_api/README.md
@@ -59,14 +59,14 @@ Docker Compose を使用して Rails6（APIモード） / MySQL5.7 の開発環�
     ```
 
 1. コンテナを立ち上げる
-   ```
+    ```shell
     $ docker compose up
     ``````
 
 1. データベースを作成
 
     ```shell
-    $ docker compose run --rm api rails db:create
+    $ docker compose run --rm web rails db:create
     ```
 
 1. 起動確認

--- a/docker/rials6_api/README.md
+++ b/docker/rials6_api/README.md
@@ -1,6 +1,6 @@
 # 開発環境セットアップ
 
-Docker Compose を使用して Rails6 / MySQL5.7 の開発環境をセットアップ〜起動する手順です。
+Docker Compose を使用して Rails6（APIモード） / MySQL5.7 の開発環境をセットアップ〜起動する手順です。
 
 ## はじめに
 
@@ -13,7 +13,7 @@ Docker Compose を使用して Rails6 / MySQL5.7 の開発環境をセットア�
 1. Rails プロジェクトを作成
 
     ```shell
-    $ docker compose run web rails new . --force --database=mysql --skip-bundle --skip-test
+    $ docker compose run api rails new . --api --force --database=mysql --skip-bundle --skip-test
     ```
 
 1. database.yml を編集
@@ -40,10 +40,10 @@ Docker Compose を使用して Rails6 / MySQL5.7 の開発環境をセットア�
 
     ```shell
     # bundle install
-    $ docker compose run --rm web bundle install
+    $ docker compose run --rm api bundle install
 
     # webpacker install
-    $ docker compose run --rm web rails webpacker:install
+    $ docker compose run --rm api rails webpacker:install
     ```
 
 1. webpacker.yml を編集
@@ -66,7 +66,7 @@ Docker Compose を使用して Rails6 / MySQL5.7 の開発環境をセットア�
 1. データベースを作成
 
     ```shell
-    $ docker compose run --rm web rails db:create
+    $ docker compose run --rm api rails db:create
     ```
 
 1. 起動確認

--- a/docker/rials6_api/docker-compose.yml
+++ b/docker/rials6_api/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+services:
+  db:
+    build:
+      context: ./mysql
+    ports:
+      - '3306:3306'
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+    volumes:
+      - ./db/mysql:/var/lib/mysql
+    networks:
+      - default
+  api: &api
+    build:
+      context: .
+    command: ./run_server.sh
+    ports:
+      - '3000:3000'
+    environment:
+      - MYSQL_HOST=db
+      - WEBPACKER_DEV_SERVER_HOST=webpacker
+    volumes:
+      - .:/project_name:cached
+      - bundle:/usr/local/bundle
+      - node_modules:/project_name/node_modules
+      - packs:/project_name/public/packs
+      - rails_cache:/project_name/tmp/cache
+    depends_on:
+      - db
+    stdin_open: true
+    tty: true
+    networks:
+      - default
+    tmpfs:
+      - /tmp
+  webpacker:
+    <<: *api
+    command: bin/webpack-dev-server
+    ports:
+      - '3035:3035'
+    environment:
+      - NODE_ENV=development
+      - RAILS_ENV=development
+      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
+    depends_on:
+      - api
+volumes:
+  bundle:
+    driver: local
+  node_modules:
+    driver: local
+  packs:
+    driver: local
+  rails_cache:
+    driver: local

--- a/docker/rials6_api/mysql/Dockerfile
+++ b/docker/rials6_api/mysql/Dockerfile
@@ -1,0 +1,8 @@
+# 2021.04.29 時点での MySQL5.7 系最新安定板
+FROM mysql:5.7.34
+
+# ローカルの my.cnf を作業ディレクトリにコピー
+ADD ./my.cnf /etc/mysql/conf.d/my.cnf
+
+# MySQL 起動
+CMD ["mysqld"]

--- a/docker/rials6_api/mysql/my.cnf
+++ b/docker/rials6_api/mysql/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+
+[client]
+default-character-set = utf8mb4

--- a/docker/rials6_api/run_server.sh
+++ b/docker/rials6_api/run_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -f tmp/pids/server.pid
+bundle exec rails s -p 3000 -b 0.0.0.0


### PR DESCRIPTION
## 概要

Rails6.0.3（APIモード） + MySQL5.7.34 のボイラープレートを新たに作成し、
合わせてREADME内の`docker-compose`コマンドを`docker compose`に修正した。
