### PR TITLE
Dockerfileを修正

### DIFF
--- a/docker/Alpine/rails6_api/Dockerfile
+++ b/docker/Alpine/rails6_api/Dockerfile
@@ -16,7 +16,8 @@ RUN apk add --no-cache --virtual build-deps \
         gcc \
         libc-dev \
         mariadb-dev \
-        nodejs~=14.17.1 \
+        tzdata \
+        nodejs~=14 \
         yarn~=1.22.10 \
         imagemagick6-dev \
         less && \


### PR DESCRIPTION
## 概要

以下の不備があったため修正した。

- nodejsのバージョン指定を`nodejs~=14.17.1`→`nodejs~=14`に修正
→バージョン指定のミスでnodejsがインストールできないため

- インストールするパッケージに`tzdata`を追加
→tzdataがないと`rails webpacker:install`実行時にエラーとなるため

## 備考

docker scanの結果は以下

|     image     | 脆弱性 |
|:-----------:|:-------:|
|       api        |   なし    |
| webpacker |   なし    |
|        db        |   あり    |

dbのみAlpine Linuxベースではないため、修正が必要
