### PR TITLE
AlpineベースのDockerfileにgitを追加

### DIFF
--- a/docker/Alpine/rails6_api/Dockerfile
+++ b/docker/Alpine/rails6_api/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache --virtual build-deps \
         nodejs~=14 \
         yarn~=1.22.10 \
         imagemagick6-dev \
+        git \
         less && \
     rm -rf /usr/lib/libmysqld* && \
     rm -rf /usr/bin/mysql*


### PR DESCRIPTION
## 概要

AlpineベースのDockerfileにgitを入れ忘れたため、プロジェクト作成時に`git init`ができていなかったため追加した。