### PR TITLE
Rubyのベースイメージをマルチステージビルドで作成

### DIFF
--- a/docker/base/README.md
+++ b/docker/base/README.md
@@ -1,0 +1,11 @@
+# ベースイメージ
+
+開発で使用する各言語のベースイメージ用のDockerfileを保存する。
+
+ディストリビューション、言語、パッケージのバージョンを上げる際はこれらのベースイメージを修正する。
+
+| directory | Linux distribution | Languages | packages |
+|:---------:|:------------------:|:---------:|:--------:|
+| Ruby | Debian 11 | Ruby（2.7.4） | node.js（16.10.0）, yarn（1.22.5） |
+
+[Ruby]:https://github.com/tom0418/Setup/tree/main/docker/base/Ruby

--- a/docker/base/Ruby/Dockerfile
+++ b/docker/base/Ruby/Dockerfile
@@ -1,0 +1,83 @@
+# Build stage just to install node.js, yarn
+FROM buildpack-deps:bullseye AS builder
+
+# install node.js
+ENV NODE_VERSION 16.10.0
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
+  && for key in \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    108F52B48DB57BB0CC439B2997B01419BD92F80A \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && bzip2 /usr/local/bin/node
+
+# install yarn
+ENV YARN_VERSION 1.22.5
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /tmp \
+  && mv yarn-v$YARN_VERSION.tar.gz /tmp/
+
+# Base ruby image
+FROM ruby:2.7.4-bullseye
+
+ENV YARN_VERSION 1.22.5
+
+ENV LANG C.UTF-8
+
+RUN apt-get update -qq \
+  && apt-get install -y build-essential \
+                        default-mysql-client \
+                        imagemagick \
+                        apt-transport-https \
+  && gem update bundler
+
+COPY --from=builder /usr/local/bin/node.bz2 /usr/local/bin/
+COPY --from=builder /tmp/yarn-v$YARN_VERSION.tar.gz /tmp/
+
+RUN bzip2 -d /usr/local/bin/node.bz2 \
+  && tar -xzf /tmp/yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm /tmp/yarn-v$YARN_VERSION.tar.gz \
+  # smoke tests
+  && node --version \
+  && yarn --version


### PR DESCRIPTION
## 概要

タイトルの通り。
イメージ自体はDocker Hubにpush済み。（t0m0418/ruby:2.7.4-bullseye）