### PR TITLE
Rails6 API（Ruby 3.0.2, MySQL 8.0.27）

### DIFF
--- a/docker/Debian/README.md
+++ b/docker/Debian/README.md
@@ -7,7 +7,7 @@ Debianベースの開発環境のボイラープレートです。
 |          directory           |   Languages   |        Framework          |    Databases    |
 |:----------------------------:|:-------------:|:-------------------------:|:---------------:|
 |       [rails6][rails6]       | Ruby（2.7.3） | Ruby on Rails（~> 6.0.3） | MySQL（5.7.34） |
-|   [rails6_api][rails6_api]   | Ruby（2.7.3） | Ruby on Rails（~> 6.0.3） | MySQL（5.7.34） |
+|   [rails6_api][rails6_api]   | Ruby（3.0.2） | Ruby on Rails（~> 6.0.3） | MySQL（8.0.27） |
 
 [rails6]:https://github.com/tom0418/Setup/tree/main/docker/Debian/rails6
 [rails6_api]:https://github.com/tom0418/Setup/tree/main/docker/Debian/rails6_api

--- a/docker/Debian/rails6_api/Dockerfile
+++ b/docker/Debian/rails6_api/Dockerfile
@@ -1,6 +1,5 @@
 FROM t0m0418/ruby:3.0.2-bullseye
 
-
 # 必要なパッケージのインストール
 # imagemagick など適宜インストールする
 

--- a/docker/Debian/rails6_api/Dockerfile
+++ b/docker/Debian/rails6_api/Dockerfile
@@ -1,15 +1,8 @@
-# 2021.04.29 時点での最新安定板
-FROM ruby:2.7.3
+FROM t0m0418/ruby:3.0.2-bullseye
 
-# ロケール環境変数をセット
-ENV LANG C.UTF-8
 
 # 必要なパッケージのインストール
-RUN apt-get update -qq && \
-    apt-get install -y build-essential \
-                       default-mysql-client \
-                       imagemagick \
-                       apt-transport-https
+# imagemagick など適宜インストールする
 
 # 作業ディレクトリの作成
 RUN mkdir /project_name
@@ -19,14 +12,8 @@ WORKDIR $API_ROOT
 # ローカルの Gemfile, Gemfile.lock を作業ディレクトリにコピーする
 COPY ./Gemfile* $API_ROOT/
 
-# yarn をインストール
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y nodejs yarn
-
 # bundle install
-RUN gem uninstall bundler && gem install -N bundler
+RUN bundle config build.nokogiri --use-system-libraries
 RUN bundle install --jobs=4
 
 # ローカルのプロジェクトを作業ディレクトリにコピーする

--- a/docker/Debian/rails6_api/README.md
+++ b/docker/Debian/rails6_api/README.md
@@ -1,6 +1,6 @@
 # 開発環境セットアップ
 
-Docker Compose を使用して Rails6（APIモード） / MySQL5.7 の開発環境をセットアップ〜起動する手順です。
+Docker Compose を使用して Rails6（APIモード） / MySQL 8.0.27 の開発環境をセットアップ〜起動する手順です。
 
 ## はじめに
 
@@ -46,19 +46,8 @@ Docker Compose を使用して Rails6（APIモード） / MySQL5.7 の開発環�
     $ docker compose run --rm api rails webpacker:install
     ```
 
-1. webpacker.yml を編集
-
-    ./config/webpacker.yml の以下項目を、docker-compose.yml で定義したservice 名に合わせて設定してください。
-
-     ```yaml:webpacker.yml
-    dev_server:
-      ...
-      host: webpacker
-      ...
-      ...
-    ```
-
 1. コンテナを立ち上げる
+
     ```shell
     $ docker compose up
     ``````

--- a/docker/Debian/rails6_api/docker-compose.yml
+++ b/docker/Debian/rails6_api/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./db/mysql:/var/lib/mysql
     networks:
       - default
-  api: &api
+  api:
     build:
       context: .
     command: ./run_server.sh
@@ -19,7 +19,6 @@ services:
       - '3000:3000'
     environment:
       - MYSQL_HOST=db
-      - WEBPACKER_DEV_SERVER_HOST=webpacker
     volumes:
       - .:/project_name:cached
       - bundle:/usr/local/bundle
@@ -34,17 +33,6 @@ services:
       - default
     tmpfs:
       - /tmp
-  webpacker:
-    <<: *api
-    command: bin/webpack-dev-server
-    ports:
-      - '3035:3035'
-    environment:
-      - NODE_ENV=development
-      - RAILS_ENV=development
-      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
-    depends_on:
-      - api
 volumes:
   bundle:
     driver: local

--- a/docker/Debian/rails6_api/mysql/Dockerfile
+++ b/docker/Debian/rails6_api/mysql/Dockerfile
@@ -1,8 +1,5 @@
-# 2021.04.29 時点での MySQL5.7 系最新安定板
-FROM mysql:5.7.34
+FROM mysql:8.0.27
 
-# ローカルの my.cnf を作業ディレクトリにコピー
 ADD ./my.cnf /etc/mysql/conf.d/my.cnf
 
-# MySQL 起動
 CMD ["mysqld"]

--- a/docker/Debian/rails6_api/mysql/my.cnf
+++ b/docker/Debian/rails6_api/mysql/my.cnf
@@ -1,6 +1,22 @@
+# MySQLサーバの設定
 [mysqld]
-character-set-server=utf8mb4
-collation-server=utf8mb4_bin
+# 文字コード/照合順序の設定
+character-set-server = utf8mb4
+collation-server = utf8mb4_bin
 
+# タイムゾーンの設定
+default-time-zone = SYSTEM
+log_timestamps = SYSTEM
+
+# デフォルト認証プラグインの設定
+default-authentication-plugin = mysql_native_password
+
+# MySQLオプションの設定
+[mysql]
+# 文字コードの設定
+default-character-set = utf8mb4
+
+# MySQLクライアントツールの設定
 [client]
+# 文字コードの設定
 default-character-set = utf8mb4


### PR DESCRIPTION
## 概要

1. Rails6 APIモードの開発環境テンプレートを以下にバージョンアップした。
    - Ruby 2.7.3 → 3.0.2（自分のDocker Hub Repositoryからベースイメージを取得）
    - MySQL 5.7.34 → 8.0.27

2. MySQLの設定を追加（my.cnfの修正）
3. API用のDockerfileを修正
    - ロケール環境変数のセットを削除（ベースイメージで設定済みのため）
    - yarnのインストールを削除（ベースイメージでインストール済みのため）
    - パッケージのインストールを削除（Railsプロジェクト作成に最低限必要なものはベースイメージでインストール済みのため）
    - nokogiriのインストールのために `RUN bundle config build.nokogiri --use-system-libraries`を追加
4. docker-compose.ymlからwebpackerを削除
5. READMEを修正
